### PR TITLE
Ensure no indexing data is added when publishing for XPM Session Preview

### DIFF
--- a/tbbs/Common/TemplateBase.cs
+++ b/tbbs/Common/TemplateBase.cs
@@ -13,6 +13,7 @@ using System.Xml;
 using Tridion.ContentManager.ContentManagement.Fields;
 using System.Xml.Linq;
 using System.Xml.Serialization;
+using Tridion.ContentManager.Publishing;
 
 namespace SI4T.Templating
 {
@@ -266,6 +267,15 @@ namespace SI4T.Templating
                 xmlData.DocumentElement.AppendChild(customNode);
                 this.PushXmlDocumentToPackage(Constants.PACKAGE_ITEM_SEARCHDATA, xmlData);
             }
+        }
+
+        /// <summary>
+        /// Determine whether we are publishing for XPM Session Preview
+        /// </summary>
+        /// <returns></returns>
+        protected bool IsFastTrackPublishing()
+        {
+            return m_Engine.RenderMode == RenderMode.PreviewDynamic && m_Engine.PublishingContext.PublicationTarget != null;
         }
 
     }

--- a/tbbs/GenerateIndexData.cs
+++ b/tbbs/GenerateIndexData.cs
@@ -19,19 +19,23 @@ namespace SI4T.Templating
 		public override void Transform(Engine engine, Package package)
 		{
             this.Initialize(engine, package);
-            //Initialize field processor from package variables
-            FieldProcessor processor = new FieldProcessor();
-            processor.Initialize(package);
-            SearchData data = new SearchData(processor);
-            if (this.IsPageTemplate)
+
+            if (IsTargetIndexed())
             {
-                UpdateFlaggedDcps(data.ProcessPage(this.GetPage()));
+                //Initialize field processor from package variables
+                FieldProcessor processor = new FieldProcessor();
+                processor.Initialize(package);
+                SearchData data = new SearchData(processor);
+                if (this.IsPageTemplate)
+                {
+                    UpdateFlaggedDcps(data.ProcessPage(this.GetPage()));
+                }
+                else
+                {
+                    data.ProcessComponentPresentation(new Tridion.ContentManager.CommunicationManagement.ComponentPresentation(this.GetComponent(), this.GetComponentTemplate()), GetFlaggedDcps());
+                }
+                SerializeAndPushToPackage(data);
             }
-            else
-            {
-                data.ProcessComponentPresentation(new Tridion.ContentManager.CommunicationManagement.ComponentPresentation(this.GetComponent(), this.GetComponentTemplate()),GetFlaggedDcps());    
-            }
-            SerializeAndPushToPackage(data);
 		}
 
         public virtual List<string> GetFlaggedDcps()
@@ -59,6 +63,13 @@ namespace SI4T.Templating
                 }
             }
             m_Engine.PublishingContext.RenderContext.ContextVariables[Constants.CONTEXT_VARIABLE_FLAGGED_DCPS] = list;
+        }
+
+        protected bool IsTargetIndexed()
+        {
+            //For Tridion next we could check if target supports search, but for now
+            //We just specifically exclude session preview only
+            return !IsFastTrackPublishing();
         }
 	}
 }


### PR DESCRIPTION
We can do this by checking RenderMode=PreviewDynamic and PublishingTarget!=null - the conditions for Session Preview publish. Note that this logic is added in a more generic IsTargetIndexed() method in the TBB which can be extended in future to check if a target has search capabilities before generating index data.