### PR TITLE
Removed adding '.' at the end

### DIFF
--- a/tbbs/Common/FieldProcessor.cs
+++ b/tbbs/Common/FieldProcessor.cs
@@ -302,7 +302,7 @@ namespace SI4T.Templating
         public virtual string XhtmlToText(string xhtml)
         {
             string res = Regex.Replace(xhtml, "</td>|</th>", " ");
-            res = Regex.Replace(xhtml, "</tr>|</p>|</div>|<br/>", ". ");
+            res = Regex.Replace(xhtml, "</tr>|</p>|</div>|<br/>", " ");
             res = Regex.Replace(res, @"\<[^\>]*\>", "");
             res = Regex.Replace(res, @"\s+", " ");
             return HttpUtility.HtmlDecode(res.Trim());
@@ -316,7 +316,14 @@ namespace SI4T.Templating
             }
             if (targetFieldName == null)
             {
-                return IndexData.CreateTextNode(value + ". ");
+                if (Regex.IsMatch(value, "[?)!.]$")) 
+                {
+                    return IndexData.CreateTextNode(value + " ");                
+                }
+                else
+                {
+                    return IndexData.CreateTextNode(value + ". ");
+                }
             }
             else
             {


### PR DESCRIPTION
Addressed issues/11 - Added a check to see if text ends with ? or ! or )
or . then skip adding ". ". Similarly, do not add '.' in place of
</tr>|</p>|</div>|<br/>